### PR TITLE
feat: change algorithm md5 to xxhash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "binconf"
-version = "0.1.601"
+version = "0.2.601"
 edition = "2021"
 authors = ["OLoKo64 <reinaldorozatoj.11cg1@aleeas.com>"]
 description = "Save and load from a binary configuration file with ease."
@@ -21,7 +21,7 @@ all-features = true
 [features]
 default = ["binary-conf"]
 full = ["binary-conf", "toml-conf", "json-conf", "yaml-conf", "ron-conf"]
-binary-conf = ["dep:bincode", "dep:md-5"]
+binary-conf = ["dep:bincode", "dep:xxhash-rust"]
 toml-conf = ["dep:toml"]
 json-conf = ["dep:serde_json"]
 yaml-conf = ["dep:serde_yaml"]
@@ -30,9 +30,9 @@ ron-conf = ["dep:ron"]
 [dependencies]
 bincode = { version = "1.3.3", optional = true }
 dirs = "5.0.1"
-md-5 = { version = "0.10.5", optional = true }
 ron = { version = "0.8.0", optional = true }
 serde = { version = "1.0.163", features = ["derive"] }
 serde_json = { version = "1.0.96", optional = true }
 serde_yaml = { version = "0.9.21", optional = true }
 toml = { version = "0.7.4", optional = true }
+xxhash-rust = { version = "0.8.6", features = ["xxh3"], optional = true }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 
 Save and load from a binary configuration file with ease.
 
-The data is hashed ([md-5](https://crates.io/crates/md-5)) during serialization and validated when deserializing, so you can be sure that the data is not corrupted.
+The data is hashed ([XXH3](https://github.com/Cyan4973/xxHash)) during serialization and validated when deserializing, so you can be sure that the data is not corrupted.
+
+Crate used for XXH3: [xxhash-rust](https://crates.io/crates/xxhash-rust)
 
 ---
 

--- a/src/binary_conf.rs
+++ b/src/binary_conf.rs
@@ -82,7 +82,7 @@ where
 ///    test_vec: Vec<u8>,
 /// }
 ///
-///let config = binconf::load_bin_skip_check("test-binconf-read-bin", None, Config, false).unwrap()
+///let config = binconf::load_bin_skip_check::<TestConfig>("test-binconf-read-bin", None, Config, false).unwrap();
 ///
 /// assert_eq!(config, TestConfig::default());
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,12 +516,20 @@ mod tests {
             ConfigLocation::Cwd,
         )
         .unwrap();
-        let ron_config =
-            get_configuration_path("test", Some("custom.ron"), ConfigType::Ron, ConfigLocation::Cwd)
-                .unwrap();
-        let bin_config =
-            get_configuration_path("test", Some("custom.bin"), ConfigType::Bin, ConfigLocation::Cwd)
-                .unwrap();
+        let ron_config = get_configuration_path(
+            "test",
+            Some("custom.ron"),
+            ConfigType::Ron,
+            ConfigLocation::Cwd,
+        )
+        .unwrap();
+        let bin_config = get_configuration_path(
+            "test",
+            Some("custom.bin"),
+            ConfigType::Bin,
+            ConfigLocation::Cwd,
+        )
+        .unwrap();
 
         let cwd_location = std::env::current_dir().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@ mod yaml_conf;
 mod ron_conf;
 
 #[cfg(feature = "binary-conf")]
-pub use binary_conf::{load_bin, store_bin};
+pub use binary_conf::{load_bin, load_bin_skip_check, store_bin};
 
 #[cfg(feature = "toml-conf")]
 pub use toml_conf::{load_toml, store_toml};
@@ -37,7 +37,7 @@ use std::io::Write;
 
 use std::path::PathBuf;
 
-/// Get the configuration file path used by `load` and `store`
+/// Get the configuration file path used by `load` and `store` functions.
 ///
 /// Useful to show the user where the configuration file is located or will be located. It does not check if the file exists.
 ///
@@ -217,6 +217,9 @@ pub enum ConfigError {
 
     #[cfg(feature = "binary-conf")]
     HashMismatch,
+
+    #[cfg(feature = "binary-conf")]
+    CorruptedHashSector,
 }
 
 impl std::error::Error for ConfigError {}
@@ -249,6 +252,9 @@ impl std::fmt::Display for ConfigError {
 
             #[cfg(feature = "binary-conf")]
             ConfigError::HashMismatch => write!(f, "Hash mismatch"),
+
+            #[cfg(feature = "binary-conf")]
+            ConfigError::CorruptedHashSector => write!(f, "Corrupted hash sector"),
         }
     }
 }


### PR DESCRIPTION
# Changes

- Change hash from `MD5` to `XXH3_128` for a big performance increase.
    - [XXHASH](https://github.com/Cyan4973/xxHash)
    - [xxhash-rust](https://crates.io/crates/xxhash-rust)
    - From my testing a 250mb file on `MD5` was around 400ms, `XXH3_128` was 20ms. A 20x improvement.
- Added `load_bin_skip_check` function, if you want to read the data even with a hash mismatch.

# THIS PR WILL BREAK ALL PREVIOUS HASH VALIDATIONS

Because the hash change all previous configurations saved will have a hash mismatch, you can use the new function `load_bin_skip_check` to get the data out.